### PR TITLE
Ignore build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ cache
 elm_dependencies
 dist/
 hello.js
+*.elmi
+*.elmo


### PR DESCRIPTION
When this project is included as a submodule (as in the Elm compiler), the submodule gets marked as "dirty" because the build artifacts register as new files.
