### PR TITLE
Add CLI option for custom entrypoint module

### DIFF
--- a/elm-io.sh
+++ b/elm-io.sh
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
-if [ "$#" -ne 2 ]; then
-    echo "Usage: $0 <generated-js-file> <output-file>"
+if [ "$#" = 3 ]; then
+    MAIN_MODULE=$3
+elif [ "$#" = 2 ]; then
+    MAIN_MODULE=Main
+else
+    echo "Usage: $0 <generated-js-file> <output-file> [<Main>]"
     exit 1
 fi
 
 read -d '' handler <<- EOF
 (function(){
     if (typeof Elm === "undefined") { throw "elm-io config error: Elm is not defined. Make sure you call elm-io with a real Elm output file"}
-    if (typeof Elm.Main === "undefined" ) { throw "Elm.Main is not defined, make sure your module is named Main." };
-    var worker = Elm.worker(Elm.Main);
+    if (typeof Elm.${MAIN_MODULE} === "undefined" ) { throw "Elm.${MAIN_MODULE} is not defined, make sure your module is named Main." };
+    var worker = Elm.worker(Elm.${MAIN_MODULE});
 })();
 EOF
 


### PR DESCRIPTION
Sometimes we want to use a different module than `Main`. For instance, we
may want to use a `MainSpec` module to run specs against our code base
with something like [elm-spec](https://github.com/avh4/elm-spec).

```elm
module MainSpec where

import IO.IO exposing (..)
import IO.Runner exposing (Request, Response, run)

import Spec.Runner.Console as Console
import Spec exposing (..)

import CSVSpec

allSpecs =
    describe "App"
      [ CSVSpec.spec
      ]

testRunner : IO ()
testRunner = Console.run allSpecs

port requests : Signal Request
port requests = run responses testRunner

port responses : Signal Response
```